### PR TITLE
Hookup CAS authentication

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,7 @@ gem 'sass-rails', '~> 5.0'
 gem 'bourbon'
 gem 'slim-rails'
 gem 'neat'
+gem 'rack-cas'
 
 # Use jquery as the JavaScript library
 gem 'jquery-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -38,6 +38,8 @@ GEM
       i18n (~> 0.7)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
+    addressable (2.5.0)
+      public_suffix (~> 2.0, >= 2.0.2)
     arel (7.1.4)
     bourbon (4.2.7)
       sass (~> 3.4)
@@ -83,8 +85,13 @@ GEM
       activerecord (>= 3.1)
       activesupport (>= 3.1)
       arel
+    public_suffix (2.0.5)
     puma (3.6.2)
     rack (2.0.1)
+    rack-cas (0.15.0)
+      addressable (~> 2.3)
+      nokogiri (~> 1.5)
+      rack (>= 1.3)
     rack-test (0.6.3)
       rack (>= 1.0)
     rails (5.0.0.1)
@@ -171,6 +178,7 @@ DEPENDENCIES
   pg (~> 0.18)
   pg_search
   puma (~> 3.0)
+  rack-cas
   rails (~> 5.0.0, >= 5.0.0.1)
   sass-rails (~> 5.0)
   slim-rails

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,11 +3,16 @@ class ApplicationController < ActionController::Base
   include ApplicationHelper
   include SessionHelper
 
+  def logout
+    unauth
+    redirect_to '/'
+  end
+
   private
 
   def require_auth
     unless authed?
-      # TODO: redirect to login url once we know what that is
+      render nothing: true, status: :unauthorized
     end
   end
 end

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -19,6 +19,8 @@ html
             == link_to 'Catalog', '/', class: ("active" if @nav == :catalog), method: :get
           li.inline
             == link_to 'My Path', '/path', class: ("active" if @nav == :path), method: :get
+          li.inline
+            == link_to 'Logout', '/logout', method: :get
         h1
           == link_to 'Curricle', root_path, class: 'logo', method: :get
       .main

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -51,4 +51,8 @@ Rails.application.configure do
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
+
+  # CAS configs
+  # When fake is true, accepts any username/password combo
+  config.rack_cas.fake = true
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -83,4 +83,9 @@ Rails.application.configure do
 
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
+
+  # CAS configs
+  # TODO: point `server_url` to HarvardKey, remove `fake` config
+  #config.rack_cas.server_url = 'https://cas.example.com/'
+  config.rack_cas.fake = true
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
+  get '/logout', to: 'application#logout'
 
   get '/courses', to: 'courses#index'
   get '/courses/search', to: 'courses#index'

--- a/db/seeds/user_seeds.rb
+++ b/db/seeds/user_seeds.rb
@@ -1,4 +1,5 @@
 User.find_or_create_by(
+  external_user_id: 'testperson',
   email: 'user@harvard.edu',
   first_name: 'Test',
   last_name: 'Person',


### PR DESCRIPTION
This PR hooks up basic CAS authentication. Both the `development` and `production` environments are currently configured to use a fake CAS server that will return valid for any username/password combo.

*In theory*, all we have to do is plugin the HarvardKey CAS server's URL and we're good to go.

TODOs worth noting:
- [Update production configs](https://github.com/berkmancenter/curricle/pull/37/files#diff-1d98f0039bbc6df92adee882ed99d993R88)
- [Potentially refactor user creation](https://github.com/berkmancenter/curricle/pull/37/files#diff-e712bd6de518d269154fb4213ea7deb5R7)