### PR TITLE
Change fill and opacity of course blocks in calendar

### DIFF
--- a/app/assets/stylesheets/_path.scss
+++ b/app/assets/stylesheets/_path.scss
@@ -97,9 +97,10 @@
 
      .class-wrapper {
         display: none;
-        background: $color-slate;
-        color: white;
-        box-shadow: 1px 2px 3px 2px rgba(0,0,0,0.75);
+        background: rgba(255,255,255,0.75);
+        color: $color-slate;
+        border: 1px solid $color-slate;
+        box-shadow: 1px 2px 6px 1px rgba(0,0,0,0.75);
         position: relative;
         z-index: 10;
         cursor: pointer;
@@ -112,7 +113,7 @@
             padding: 3px 4px;
             background: none;
             border: none;
-            color: white;
+            color: $color-slate;
             cursor: pointer;
             font-size: 20px;
             line-height: 12px;
@@ -130,12 +131,26 @@
 
           &.recommended {
             display: block;
-            background: $color-green;
+            background: rgba(91,182,136,0.85);
+            color: $color-white;
+
+            .add-remove {
+              input[type="submit"] {
+                color: $color-white;
+              }
+            }
           }
 
           &.active {
             z-index: 11;
             background: $color-gray !important;
+            color: white;
+
+            .add-remove {
+              input[type="submit"] {
+                color: $color-white;
+              }
+            }
           }
         }
      }
@@ -174,11 +189,11 @@
         position: absolute;
         left: 4px;
         right: 4px;
-        opacity: 0.95;
 
         .title {
           text-align: center;
-          padding: 22px 10px;
+          padding: 20px 10px 0;
+          opacity: 1;
         }
       }
     }
@@ -221,7 +236,8 @@
       border: 1px solid gray;
       position: relative;
       border: 1px solid $color-slate;
-      color: $color-slate;
+      background: $color-slate;
+      color: $color-white;
       cursor: pointer;
 
       &.visible {
@@ -237,19 +253,19 @@
       input[type="submit"] {
         cursor: pointer;
         margin-top: 10px;
-        color: $color-slate;
+        color: $color-white;
         background: none;
-        border: 1px solid $color-slate;
+        border: 1px solid $color-white;
         border-radius: 3px;
       }
 
       &.in-path {
-        color: white;
-        background: $color-slate;
+        color: $color-slate;
+        background: $color-white;
 
         input[type="submit"] {
-          color: white;
-          border: 1px solid white;
+          color: $color-slate;
+          border: 1px solid $color-slate;
         }
       }
 


### PR DESCRIPTION
Addresses #43 

This PR restyles the course blocks in the calendar view so that overlapping courses are easier to distinguish. It includes the following changes:

- Courses that have been added to your path are now white instead of gray.
- Course that are in your tray but not your path are now gray instead of white.
- Opacity has been moved from the entire course element to just the fill color (meaning the text isn't transparent).
- Recommended courses are now semi-transparent (in case you add a class to your path that overlaps a recommended course).

<img width="513" alt="screenshot 2017-03-10 14 32 23" src="https://cloud.githubusercontent.com/assets/272702/23813137/17b6510e-05a3-11e7-8091-62f0047e48ef.png">