### PR TITLE
Handle missing units

### DIFF
--- a/app/services/recommendation_service.rb
+++ b/app/services/recommendation_service.rb
@@ -13,7 +13,7 @@ class RecommendationService
       # remove any courses from consideration that
       # - don't have a units value OR
       # - are worth more units than we have remaining
-      available.delete_if { |r| r.course.units_maximum.nil? || r.course.units_maximum > units_remaining }
+      available.delete_if { |r| r.course.units_maximum.blank? || r.course.units_maximum > units_remaining }
 
       # select a course
       rec = available.pop


### PR DESCRIPTION
This PR updates the recommendation engine to account for courses that might not have a `units_maximum` value by removing those courses from consideration.

Resolves issue #57